### PR TITLE
Parameter 'hUnwrappedKey' assigned with a valid value.

### DIFF
--- a/Tokend/Tokend/KeyHandle.cpp
+++ b/Tokend/Tokend/KeyHandle.cpp
@@ -141,6 +141,7 @@ void KeyHandle::unwrapKey(const Context &context,
 	/* We are assuming a CSSM_KEYBLOB_WRAPPED_FORMAT_PKCS7 from here on. */
 	hdr.blobFormat(CSSM_KEYBLOB_RAW_FORMAT_OCTET_STRING);
 	hdr.LogicalKeySizeInBits = unwrappedKey.length() * 8;
+    hUnwrappedKey = CSSM_HANDLE(static_cast<CSSM_HANDLE_PTR>(unwrappedKey.data()));
 }
 
 


### PR DESCRIPTION
This fixes a problem when the referenced variable is (randomly) initialized to 0 and SecurityTokend consequently throws an exception with CSSMERR_CSSM_INVALID_ADDIN_HANDLE error.
