### PR TITLE
Fix compilation with gcc >= 6

### DIFF
--- a/SmartCardServices/src/PKCS11dotNetV2/CardModuleService.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/CardModuleService.hpp
@@ -25,12 +25,12 @@
 
 #include <string>
 #include <boost/ptr_container/ptr_map.hpp>
+#include "Log.hpp"
 #include "MarshallerCfg.h"
 #include "Array.hpp"
 #include "Marshaller.h"
 #include "Except.h"
 #include "Timer.hpp"
-#include "Log.hpp"
 
 
 const unsigned char CARD_FREE_SPACE  = 0x00; //Returns a byte array blob of 12 bytes

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainer.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainer.hpp
@@ -29,8 +29,8 @@
 #include <boost/serialization/version.hpp>
 #include <boost/shared_ptr.hpp>
 #include "Array.hpp"
-#include "cardmod.h"
 #include "Log.hpp"
+#include "cardmod.h"
 #include "MiniDriverAuthentication.hpp"
 
 

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.cpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.cpp
@@ -22,10 +22,8 @@
 #include <cstdio>
 #include <boost/foreach.hpp>
 #include <memory>
-#include "cardmod.h"
 #include "MiniDriverContainerMapFile.hpp"
 #include "MiniDriverFiles.hpp"
-#include "Log.hpp"
 #include "Timer.hpp"
 #include "MiniDriverException.hpp"
 #include "sha1.h"

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.hpp
@@ -29,9 +29,10 @@
 #include <boost/array.hpp>
 #include <boost/shared_ptr.hpp>
 #include <string>
-#include "MiniDriverContainer.hpp"
+#include "Log.hpp"
 #include "Array.hpp"
 #include "CardModuleService.hpp"
+#include "MiniDriverContainer.hpp"
 
 
 const int g_MaxContainer = 15;


### PR DESCRIPTION
This fixes build issues with gcc-6.4.0 on Gentoo. 

The original error message is
> /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/include/g++-v6/bits/locale_conv.h: In member function ‘std::__cxx11::wstring_convert<_Codecvt, _Elem, _Wide_alloc, _Byte_alloc>::wide_string std::__cxx11::wstring_convert<_Codecvt, _Elem, _Wide_alloc, _Byte_alloc>::from_bytes(const char*, const char*)’:
/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/include/g++-v6/bits/locale_conv.h:253:45: error: expected primary-expression before ‘,’ token
  if (__str_codecvt_in(__first, __last, __out, *_M_cvt, _M_state,
                                             ^
/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/include/g++-v6/bits/locale_conv.h:255:4: error: return-statement with no value, in function returning ‘std::__cxx11::wstring_convert<_Codecvt, _Elem, _Wide_alloc, _Byte_alloc>::wide_string’ [-fpermissive]
    return __out; 
    ^~~~~~
