### PR TITLE
PKCS11dotNetV2: Use std::array instead of boost::array

### DIFF
--- a/SmartCardServices/src/PKCS11dotNetV2/Application.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/Application.hpp
@@ -28,7 +28,7 @@
 #include "DeviceMonitor.hpp"
 #include "IDeviceMonitorListener.hpp"
 #include "Slot.hpp"
-#include <boost/array.hpp>
+#include <array>
 
 
 const int g_iMaxSlot = 5;
@@ -44,7 +44,7 @@ class Application : public IDeviceMonitorListener {
 
 public:
 
-	typedef boost::array< boost::shared_ptr< Slot >, g_iMaxSlot > ARRAY_SLOTS;
+	typedef std::array< boost::shared_ptr< Slot >, g_iMaxSlot > ARRAY_SLOTS;
 
 	Application( );
 

--- a/SmartCardServices/src/PKCS11dotNetV2/DeviceMonitor.cpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/DeviceMonitor.cpp
@@ -702,7 +702,7 @@ void DeviceMonitor::printDeviceList( void ) {
 
 /*
 */
-void DeviceMonitor::printReaderStateList( boost::array< SCARD_READERSTATE, g_iMaxReader + 1 >& l ) {
+void DeviceMonitor::printReaderStateList( std::array< SCARD_READERSTATE, g_iMaxReader + 1 >& l ) {
 
     int i = 0;
 

--- a/SmartCardServices/src/PKCS11dotNetV2/DeviceMonitor.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/DeviceMonitor.hpp
@@ -26,8 +26,8 @@
 #include <vector>
 #include <string>
 #include <list>
+#include <array>
 #include <boost/shared_ptr.hpp>
-#include <boost/array.hpp>
 #include <boost/thread.hpp>
 
 
@@ -59,7 +59,7 @@ public:
 
     virtual ~DeviceMonitor( ) { }
 
-    typedef boost::array< boost::shared_ptr< Device >, g_iMaxReader > DEVICES;
+    typedef std::array< boost::shared_ptr< Device >, g_iMaxReader > DEVICES;
 
 	inline DEVICES& getDeviceList( void ) { return m_aDevices; };
 
@@ -125,7 +125,7 @@ private:
 	
 	void printReaderState( const SCARD_READERSTATE& scrs, const int& iIndex );
 	void printDeviceList( void );
-	void printReaderStateList( boost::array< SCARD_READERSTATE, g_iMaxReader + 1 >& );
+	void printReaderStateList( std::array< SCARD_READERSTATE, g_iMaxReader + 1 >& );
 	void getState( const DWORD& dwState, std::string& stState );
 
 };

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverContainerMapFile.hpp
@@ -26,8 +26,8 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/array.hpp>
 #include <boost/shared_ptr.hpp>
+#include <array>
 #include <string>
 #include "Log.hpp"
 #include "Array.hpp"
@@ -49,7 +49,7 @@ public:
 
     static unsigned char CONTAINER_INDEX_INVALID;
 
-    typedef boost::array< MiniDriverContainer, g_MaxContainer > ARRAY_CONTAINERS;
+    typedef std::array< MiniDriverContainer, g_MaxContainer > ARRAY_CONTAINERS;
 
     MiniDriverContainerMapFile( ) { }
 

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverPinPolicy.cpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverPinPolicy.cpp
@@ -34,7 +34,7 @@ void MiniDriverPinPolicy::write( void ) {
     
     Marshaller::u1Array b( g_PolicyLenght );
 
-    b.SetBuffer( m_ucaPinPolicy.c_array( ) );
+    b.SetBuffer( &m_ucaPinPolicy[0] );
 
     try {
 
@@ -62,7 +62,7 @@ void MiniDriverPinPolicy::read( void ) {
     
         if( b.get( ) ) {
 
-            memcpy( m_ucaPinPolicy.c_array( ), b->GetBuffer( ), m_ucaPinPolicy.size( ) );
+            memcpy( &m_ucaPinPolicy[0], b->GetBuffer( ), m_ucaPinPolicy.size( ) );
         }
 
     } catch( MiniDriverException& ) {

--- a/SmartCardServices/src/PKCS11dotNetV2/MiniDriverPinPolicy.hpp
+++ b/SmartCardServices/src/PKCS11dotNetV2/MiniDriverPinPolicy.hpp
@@ -26,8 +26,8 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/version.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/array.hpp>
 #include <boost/foreach.hpp>
+#include <array>
 #include <memory>
 #include "CardModuleService.hpp"
 
@@ -112,7 +112,7 @@ public:
 
 protected:
 
-    inline void reset( void ) { memset( m_ucaPinPolicy.c_array( ), 0, sizeof( m_ucaPinPolicy ) ); }
+    inline void reset( void ) { memset( &m_ucaPinPolicy[0], 0, sizeof( m_ucaPinPolicy ) ); }
 
     inline void set( unsigned char const & a_ucParameterIndex, unsigned char const & a_ucParameterValue ) { m_ucaPinPolicy[ a_ucParameterIndex ] = a_ucParameterValue; }
 
@@ -122,7 +122,7 @@ protected:
 
     CardModuleService* m_CardModule;
 
-    boost::array< unsigned char, g_PolicyLenght > m_ucaPinPolicy;
+    std::array< unsigned char, g_PolicyLenght > m_ucaPinPolicy;
 
     unsigned char m_ucRole;
 


### PR DESCRIPTION
With boost 1.66.0 one keeps getting compiler errors
about undefined .serialize() method on boost arrays
    
    /usr/local/include/boost/serialization/access.hpp:116:11:
    error: no member named 'serialize' in
          'boost::array<MiniDriverContainer, 15>'
            t.serialize(ar, file_version);
            ~ ^

By submitting a request, I represent that I have the right to license
my contribution to the community, and agree that my contributions are
licensed under the [GNU Lesser General Public License Version
2.1](SmartCardServices/src/PKCS11dotNetV2/LGPL-2.1) for  the PKCS11dotNetV2
subproject of the Smart Card Services project).

For existing files modified by my request, I represent that I have
retained any existing copyright notices and licensing terms. I have
not added any new files.

Having said all the above I belive that this contribution is so trivial
that it cannot be considered original work at all.